### PR TITLE
Package.json points to non-existent file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "request": "^2.44.0",
     "socket.io": "^1.1.0"
   },
-  "main": "./js/dist/builds/core",
-  "browserify": "./js/dist/builds/core"
+  "main": "./js/builds/core",
+  "browserify": "./js/builds/core"
 }


### PR DESCRIPTION
The `main` and `browserify` keys point to non-existent paths. This prevents RequireJS from requiring Forerunner correctly.