### PR TITLE
bug fixed: if val[pk] is number 0  it cant' find the value

### DIFF
--- a/js/lib/KeyValueStore.js
+++ b/js/lib/KeyValueStore.js
@@ -112,7 +112,7 @@ KeyValueStore.prototype.lookup = function (val) {
 			}
 
 			return result;
-		} else if (val[pk]) {
+		} else if (val[pk] !== undefined && val[pk] !== null) {
 			return this.lookup(val[pk]);
 		}
 	}


### PR DESCRIPTION
if val[pk] is number 0  it cant' find the value